### PR TITLE
Fix NuGet push wildcard pattern

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,7 +90,7 @@ jobs:
       - name: 🚀 Publish to NuGet.org (Releases only)
         if: github.event_name == 'release'
         run: |
-          dotnet nuget push source/timewarp-source-generators/bin/Release/TimeWarp.SourceGenerators.*.nupkg `
+          dotnet nuget push source/timewarp-source-generators/bin/Release/*.nupkg `
             --api-key ${{ secrets.PUBLISH_TO_NUGET_ORG }} `
             --source https://api.nuget.org/v3/index.json `
             --skip-duplicate


### PR DESCRIPTION
Fix the NuGet push command to use *.nupkg wildcard instead of specific package name pattern, since the actual file is lowercase (timewarp-source-generators.*.nupkg)