### PR TITLE
Fix NuGet package naming and symbol package issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,7 +90,7 @@ jobs:
       - name: 🚀 Publish to NuGet.org (Releases only)
         if: github.event_name == 'release'
         run: |
-          dotnet nuget push source/timewarp-source-generators/bin/Release/*.nupkg `
+          dotnet nuget push source/timewarp-source-generators/bin/Release/TimeWarp.SourceGenerators.*.nupkg `
             --api-key ${{ secrets.PUBLISH_TO_NUGET_ORG }} `
             --source https://api.nuget.org/v3/index.json `
             --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <Authors>Steven T. Cramer</Authors>
     <Product>TimeWarp.SourceGenerators</Product>
+    <PackageId>TimeWarp.SourceGenerators</PackageId>
     <PackageVersion>1.0.0-beta.1</PackageVersion>
     <PackageProjectUrl>https://timewarpengineering.github.io/timewarp-source-generators/</PackageProjectUrl>
     <PackageTags>TimeWarp; Source Generator;SourceGenerators; Delegate</PackageTags>


### PR DESCRIPTION
## Summary
- Add explicit PackageId to ensure package publishes as `TimeWarp.SourceGenerators` instead of using the kebab-case project filename
- Fix CI/CD workflow to only push the main NuGet package, excluding symbol packages that were causing publish errors

## Changes
1. Added `<PackageId>TimeWarp.SourceGenerators</PackageId>` to Directory.Build.props
2. Updated NuGet push command to use explicit package name pattern: `TimeWarp.SourceGenerators.*.nupkg`

## Test plan
- [ ] CI/CD workflow runs successfully
- [ ] Package publishes to NuGet.org with correct name: `TimeWarp.SourceGenerators`
- [ ] No symbol package errors during publish

🤖 Generated with [Claude Code](https://claude.ai/code)