### PR TITLE
Disable symbol packages and bump to beta.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>Steven T. Cramer</Authors>
     <Product>TimeWarp.SourceGenerators</Product>
     <PackageId>TimeWarp.SourceGenerators</PackageId>
-    <PackageVersion>1.0.0-beta.1</PackageVersion>
+    <PackageVersion>1.0.0-beta.2</PackageVersion>
     <PackageProjectUrl>https://timewarpengineering.github.io/timewarp-source-generators/</PackageProjectUrl>
     <PackageTags>TimeWarp; Source Generator;SourceGenerators; Delegate</PackageTags>
     <PackageIcon>logo.png</PackageIcon>
@@ -46,8 +46,7 @@
 
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>false</IncludeSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Disable symbol package generation to fix NuGet push errors
- Bump version to 1.0.0-beta.2

## Changes
1. Set `<IncludeSymbols>false</IncludeSymbols>` in Directory.Build.props
2. Removed `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` as it's no longer needed
3. Updated version from beta.1 to beta.2

## Why
The previous release failed because NuGet.org rejected the symbol package (.snupkg) with error 400: "The package does not contain any symbol (.pdb) files." By disabling symbol package generation entirely, we avoid this issue.

## Test plan
- [ ] CI/CD workflow runs successfully
- [ ] No .snupkg files are generated
- [ ] Package publishes successfully to NuGet.org as TimeWarp.SourceGenerators v1.0.0-beta.2

🤖 Generated with [Claude Code](https://claude.ai/code)